### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,7 @@ nn.move_to(ORIGIN)
 self.add(nn)
 # Make a forward pass animation
 forward_pass = nn.make_forward_pass_animation()
+self.play(forward_pass)
 ```
 
 We can now render with:


### PR DESCRIPTION
A line `self.play(forward_pass)` was missing causing the manim not to generate the animation when user copy/paste the example blindly. The example supposed to create animation of CNN.